### PR TITLE
Add to cart event corrected to have item array instead of basket array

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -208,6 +208,11 @@ ___TEMPLATE_PARAMETERS___
             "paramName": "type",
             "paramValue": "checkAvailability",
             "type": "EQUALS"
+          },
+          {
+            "paramName": "type",
+            "paramValue": "addToCart",
+            "type": "EQUALS"
           }
         ],
         "valueValidators": [
@@ -249,11 +254,6 @@ ___TEMPLATE_PARAMETERS___
           {
             "paramName": "type",
             "paramValue": "trackTransaction",
-            "type": "EQUALS"
-          },
-          {
-            "paramName": "type",
-            "paramValue": "addToCart",
             "type": "EQUALS"
           }
         ],


### PR DESCRIPTION
Currently the addToCart event only allows the addition of the basket array, however the item array is actually needed as per the documentation:
https://help.criteo.com/kb/guide/en/all-criteo-onetag-events-and-parameters-vZbzbEeY86/Steps/775825,868653,2796774

Removed basket array and added item array for the addToCart event.